### PR TITLE
Add `analytics_api` to nginx config.

### DIFF
--- a/playbooks/analytics_sandbox.yml
+++ b/playbooks/analytics_sandbox.yml
@@ -25,6 +25,8 @@
     - role: nginx
       nginx_sites:
         - insights
+        - analytics_api
+      tags: nginx
     - insights
     - role: postfix_queue
       when: POSTFIX_QUEUE_EXTERNAL_SMTP_HOST != ''


### PR DESCRIPTION
Otherwise we cannot access it.

(I guess I should've fixed the git author config before committing, but whatever :P )